### PR TITLE
[FIXED]: Increase in training time after each batch

### DIFF
--- a/src/bin/nn.rs
+++ b/src/bin/nn.rs
@@ -2,9 +2,9 @@ use tinygrad_rust::{datasets::{mnist, PX_SIZE}, neural_net};
 
 fn main() {
     let mnist_dataloader = mnist::load_data();
-    let batch_size = 60;
-    let epochs = 5;
-    let mut model = neural_net::Model::init(PX_SIZE * PX_SIZE, 10, vec![8], mnist_dataloader);
+    let batch_size = 10;
+    let epochs =30;
+    let mut model = neural_net::Model::init(PX_SIZE * PX_SIZE, 10, vec![16, 16], mnist_dataloader);
 
     model.train(batch_size, epochs)
 }

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -245,6 +245,10 @@ impl Tensor {
             }
         }
     }
+
+    pub fn update_requires_grad(&self, requires_grad: Option<bool>) {
+        self.requires_grad.set(requires_grad);
+    }
 }
 
 impl BinaryOps for Rc<Tensor> {


### PR DESCRIPTION
After refactoring the neural net code to use the new tensor lib, there was a perf issue when training the data. In particular after batch, it progressively got slower. The issue was with the line that was updating the weights. However each of these updates is an op which was adding nodes to the computational graph even because of how the `requires_grad` flag was implemented. Hence after each batch the backprop had to be done on a larger and larger computational graph which was causing the issue.
The issue has been fixed temporarily by not having the operation done through tensors (there by not needing to think about the computational graph at all) but through raw ndarrays and then assigning a new tensor from it after all ops are done